### PR TITLE
Add support for viewing details of saved configurations

### DIFF
--- a/cloudinary_cli/core/config.py
+++ b/cloudinary_cli/core/config.py
@@ -1,20 +1,22 @@
 import cloudinary
-from click import command, option, echo
+from click import command, option, echo, BadParameter
 
 from cloudinary_cli.defaults import logger
-from cloudinary_cli.utils.config_utils import load_config, verify_cloudinary_url, update_config, remove_config_keys
+from cloudinary_cli.utils.config_utils import load_config, verify_cloudinary_url, update_config, remove_config_keys, \
+    show_cloudinary_config
 
 
 @command("config", help="Display the current configuration, and manage additional configurations.")
 @option("-n", "--new", help="""\b Create and name a configuration from a Cloudinary account environment variable.
 e.g. cld config -n <NAME> <CLOUDINARY_URL>""", nargs=2)
 @option("-ls", "--ls", help="List all saved configurations.", is_flag=True)
+@option("-s", "--show", help="Show details of a specified configuration.", nargs=1)
 @option("-rm", "--rm", help="Delete a specified configuration.", nargs=1)
 @option("-url", "--from_url",
         help="Create a configuration from a Cloudinary account environment variable. "
              "The configuration name is the cloud name.",
         nargs=1)
-def config(new, ls, rm, from_url):
+def config(new, ls, show, rm, from_url):
     if new or from_url:
         config_name, cloudinary_url = new or [None, from_url]
 
@@ -31,10 +33,17 @@ def config(new, ls, rm, from_url):
         if remove_config_keys(rm):
             logger.warn(f"Configuration '{rm}' not found.")
         else:
-            logger.info(f"Configuration '{rm}' deleted")
+            logger.info(f"Configuration '{rm}' deleted.")
     elif ls:
         echo("\n".join(load_config().keys()))
+    elif show:
+        curr_config = load_config()
+        if show not in curr_config:
+            raise BadParameter(f"Configuration {show} does not exist, use -ls to list available configurations.")
+
+        config_obj = cloudinary.Config()
+        # noinspection PyProtectedMember
+        config_obj._setup_from_parsed_url(config_obj._parse_cloudinary_url(load_config()[show]))
+        show_cloudinary_config(config_obj)
     else:
-        obfuscated_config = {k: v if k != "api_secret" else "***************{}".format(v[-4:])
-                             for k, v in cloudinary.config().__dict__.items()}
-        echo('\n'.join(["{}:\t{}".format(k, v) for k, v in obfuscated_config.items()]))
+        show_cloudinary_config(cloudinary.config())

--- a/cloudinary_cli/utils/config_utils.py
+++ b/cloudinary_cli/utils/config_utils.py
@@ -2,6 +2,7 @@
 import os
 
 import cloudinary
+from click import echo
 from cloudinary import api
 
 from cloudinary_cli.defaults import CLOUDINARY_CLI_CONFIG_FILE, OLD_CLOUDINARY_CLI_CONFIG_FILE, logger
@@ -51,6 +52,12 @@ def verify_cloudinary_url(cloudinary_url):
     return True
 
 
+def show_cloudinary_config(cloudinary_config):
+    obfuscated_config = {k: v if k != "api_secret" else "***************{}".format(v[-4:])
+                         for k, v in cloudinary_config.__dict__.items() if not k.startswith("_")}
+    echo('\n'.join(["{}:\t{}".format(k, v) for k, v in obfuscated_config.items()]))
+
+
 def migrate_old_config():
     """
     Migrate old config file (if exists) to new location
@@ -76,3 +83,4 @@ def initialize():
 
 def _verify_file_path(file):
     os.makedirs(os.path.dirname(file), exist_ok=True)
+


### PR DESCRIPTION
### Brief Summary of Changes
Add `cld config -s <config name>` command for viewing details of the specified saved configuration.

#### What does this PR address?
[ ] Github issue (Add reference - #XX)
[ ] Refactoring
[x] New feature
[ ] Bug fix
[ ] Adds more tests

#### Are tests included?
[ ] Yes
[x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
