### PR TITLE
Generate Signed URLs for assets with Access Mode: Authenticated

### DIFF
--- a/cloudinary_cli/utils/api_utils.py
+++ b/cloudinary_cli/utils/api_utils.py
@@ -39,6 +39,7 @@ def query_cld_folder(folder):
                 "format": asset['format'],
                 "etag": asset.get('etag', '0'),
                 "relative_path": rel_path,  # save for inner use
+                "access_mode": asset.get('access_mode', 'public'),
             }
         # use := when switch to python 3.8
         next_cursor = res.get('next_cursor')
@@ -72,7 +73,7 @@ def download_file(remote_file, local_path, downloaded=None, failed=None):
     failed = failed if failed is not None else {}
     makedirs(path.dirname(local_path), exist_ok=True)
 
-    sign_url = True if remote_file['type'] in ("private", "authenticated") else False
+    sign_url = True if remote_file['type'] in ("private", "authenticated") or remote_file["access_mode"] == "authenticated" else False
 
     download_url = cloudinary_url(asset_source(remote_file), resource_type=remote_file['resource_type'],
                                   type=remote_file['type'], sign_url=sign_url)[0]

--- a/cloudinary_cli/utils/api_utils.py
+++ b/cloudinary_cli/utils/api_utils.py
@@ -73,7 +73,10 @@ def download_file(remote_file, local_path, downloaded=None, failed=None):
     failed = failed if failed is not None else {}
     makedirs(path.dirname(local_path), exist_ok=True)
 
-    sign_url = True if remote_file['type'] in ("private", "authenticated") or remote_file["access_mode"] == "authenticated" else False
+    if remote_file['type'] in ("private", "authenticated") or remote_file['access_mode'] == "authenticated":
+        sign_url = True
+    else:
+        sign_url = False
 
     download_url = cloudinary_url(asset_source(remote_file), resource_type=remote_file['resource_type'],
                                   type=remote_file['type'], sign_url=sign_url)[0]


### PR DESCRIPTION
### Brief Summary of Changes

Currently, for `download_files`, we only sign URLs if the `type` is `private`/`authenticated` but any assets already uploaded with `access_mode: authenticated` can't be downloaded without a valid signed URL. Adding change to also sign if the asset in question has access mode set. Otherwise, Sync Pull actions will fail for such assets.

Via the CLI, Access Mode isn't supported to be set (such as via the upload() method of Upload API) nor does it contain `update_access_mode_*` methods as part of the Admin API though for Sync purposes I think it makes sense to be able to download previously uploaded assets with access_mode.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [X] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.
