### PR TITLE
Ability to upload contents of directory only without creating the parent directory in Cloudinary.

### DIFF
--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -65,9 +65,7 @@ def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, opti
             if not include_hidden and is_hidden_path(file_path):
                 continue
 
-            destination_folder = get_destination_folder(folder, str(file_path), parent=parent)
-
-            options = {**options, "folder": destination_folder}
+            options = {**options, "folder": get_destination_folder(folder, str(file_path), parent=parent)}
             uploads.append((file_path, options, items, skipped))
 
     run_tasks_concurrently(upload_file, uploads, concurrent_workers)

--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -40,8 +40,13 @@ def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, opti
         logger.error(f"Directory: {dir_to_upload} does not exist")
         return False
 
-    logger.info(f"Uploading directory '{dir_to_upload}'")
-    parent = dirname(dir_to_upload)
+    if use_parent_dir:
+        logger.info(f"Uploading directory '{dir_to_upload}'")
+        parent = dirname(dir_to_upload)
+    else:
+        logger.info(f"Uploading contents of directory '{dir_to_upload}'")
+        parent = dir_to_upload
+
     options = {
         **{k: v for k, v in optional_parameter},
         **{k: parse_option_value(v) for k, v in optional_parameter_parsed},
@@ -60,10 +65,7 @@ def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, opti
             if not include_hidden and is_hidden_path(file_path):
                 continue
 
-            if use_parent_dir:
-                destination_folder = get_destination_folder(folder, str(file_path), parent=parent)
-            else:
-                destination_folder = get_destination_folder(folder, str(file_path))
+            destination_folder = get_destination_folder(folder, str(file_path), parent=parent)
 
             options = {**options, "folder": destination_folder}
             uploads.append((file_path, options, items, skipped))

--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -23,11 +23,11 @@ from cloudinary_cli.utils.utils import parse_option_value, logger, run_tasks_con
 @option("-f", "--folder", default="",
         help="The Cloudinary folder where you want to upload the assets. "
              "You can specify a whole path, for example folder1/folder2/folder3. "
-             "Any folders that do not exist are automatically created.")
+             "If your product environment uses fixed folder mode, then any folders that do not exist are automatically created.")
 @option("-p", "--preset", help="The upload preset to use.")
 @option("-e", "--exclude-dir-name", is_flag=True, default=False,
-        help="Exclude the directory name from the folder structure in Cloudinary. "
-             "This avoids creating the parent directory as a sub-folder of the --(f)older in Cloudinary. "
+        help="Don't include the selected parent directory name in the public ID path of the uploaded files."
+             "This ensures that the public ID paths of the uploaded assets will be directly under the specified --(f)older, avoiding an extraneous level in the path."
              "When this option is used the contents of the directory is uploaded instead of the directory itself. ")
 @option("-w", "--concurrent_workers", type=int, default=30, help="Specify the number of concurrent network threads.")
 def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, optional_parameter_parsed, transformation,

--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -28,7 +28,7 @@ from cloudinary_cli.utils.utils import parse_option_value, logger, run_tasks_con
 @option("-e", "--exclude-dir-name", is_flag=True, default=False,
         help="Don't include the selected parent directory name in the public ID path of the uploaded files."
              "This ensures that the public ID paths of the uploaded assets will be directly under the specified --(f)older, avoiding an extraneous level in the path."
-             "When this option is used, the contents of the parent directory are uploaded instead of the parent directory itself and thus the name of the specified parent directory is not included in the pubic ID path of the uploaded assets.)
+             "When this option is used, the contents of the parent directory are uploaded instead of the parent directory itself and thus the name of the specified parent directory is not included in the pubic ID path of the uploaded assets.")
 @option("-w", "--concurrent_workers", type=int, default=30, help="Specify the number of concurrent network threads.")
 def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, optional_parameter_parsed, transformation,
                folder, preset, concurrent_workers, exclude_dir_name):

--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -25,14 +25,13 @@ from cloudinary_cli.utils.utils import parse_option_value, logger, run_tasks_con
              "You can specify a whole path, for example folder1/folder2/folder3. "
              "Any folders that do not exist are automatically created.")
 @option("-p", "--preset", help="The upload preset to use.")
-@option(" /-P", "--use-parent-dir/--dont-use-parent-dir",
-        default=True,
-        help="If \"--use-parent-dir\" is set, default behavior, the parent directory would be created as a subfolder of"
-             "the --(f)older in Cloudinary. "
-             "If \"--dont-use-parent-dir\" is set, only upload the contents of the directory argument.")
+@option("-e", "--exclude-dir-name", is_flag=True, default=False,
+        help="Exclude the directory name from the folder structure in Cloudinary. "
+             "This avoids creating the parent directory as a sub-folder of the --(f)older in Cloudinary. "
+             "When this option is used the contents of the directory is uploaded instead of the directory itself. ")
 @option("-w", "--concurrent_workers", type=int, default=30, help="Specify the number of concurrent network threads.")
 def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, optional_parameter_parsed, transformation,
-               folder, preset, concurrent_workers, use_parent_dir):
+               folder, preset, concurrent_workers, exclude_dir_name):
     items, skipped = {}, {}
 
     dir_to_upload = Path(path_join(getcwd(), directory))
@@ -40,12 +39,12 @@ def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, opti
         logger.error(f"Directory: {dir_to_upload} does not exist")
         return False
 
-    if use_parent_dir:
-        logger.info(f"Uploading directory '{dir_to_upload}'")
-        parent = dirname(dir_to_upload)
-    else:
+    if exclude_dir_name:
         logger.info(f"Uploading contents of directory '{dir_to_upload}'")
         parent = dir_to_upload
+    else:
+        logger.info(f"Uploading directory '{dir_to_upload}'")
+        parent = dirname(dir_to_upload)
 
     options = {
         **{k: v for k, v in optional_parameter},

--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -28,7 +28,7 @@ from cloudinary_cli.utils.utils import parse_option_value, logger, run_tasks_con
 @option("-e", "--exclude-dir-name", is_flag=True, default=False,
         help="Don't include the selected parent directory name in the public ID path of the uploaded files."
              "This ensures that the public ID paths of the uploaded assets will be directly under the specified --(f)older, avoiding an extraneous level in the path."
-             "When this option is used the contents of the directory is uploaded instead of the directory itself. ")
+             "When this option is used, the contents of the parent directory are uploaded instead of the parent directory itself and thus the name of the specified parent directory is not included in the pubic ID path of the uploaded assets.)
 @option("-w", "--concurrent_workers", type=int, default=30, help="Specify the number of concurrent network threads.")
 def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, optional_parameter_parsed, transformation,
                folder, preset, concurrent_workers, exclude_dir_name):

--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -25,9 +25,12 @@ from cloudinary_cli.utils.utils import parse_option_value, logger, run_tasks_con
              "You can specify a whole path, for example folder1/folder2/folder3. "
              "Any folders that do not exist are automatically created.")
 @option("-p", "--preset", help="The upload preset to use.")
+@option("-c", "--directory-contents-only", is_flag=True, help="Avoid creating the directory as a subfolder of the "
+                                                              "--(f)older in Cloudinary. This will only upload the "
+                                                              "contents of the directory argument.")
 @option("-w", "--concurrent_workers", type=int, default=30, help="Specify the number of concurrent network threads.")
 def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, optional_parameter_parsed, transformation,
-               folder, preset, concurrent_workers):
+               folder, preset, concurrent_workers, directory_contents_only):
     items, skipped = {}, {}
 
     dir_to_upload = Path(path_join(getcwd(), directory))
@@ -55,7 +58,12 @@ def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, opti
             if not include_hidden and is_hidden_path(file_path):
                 continue
 
-            options = {**options, "folder": get_destination_folder(folder, str(file_path), parent=parent)}
+            if directory_contents_only:
+                destination_folder = get_destination_folder(folder, str(file_path))
+            else:
+                destination_folder = get_destination_folder(folder, str(file_path), parent=parent)
+
+            options = {**options, "folder": destination_folder}
             uploads.append((file_path, options, items, skipped))
 
     run_tasks_concurrently(upload_file, uploads, concurrent_workers)

--- a/cloudinary_cli/modules/upload_dir.py
+++ b/cloudinary_cli/modules/upload_dir.py
@@ -25,12 +25,14 @@ from cloudinary_cli.utils.utils import parse_option_value, logger, run_tasks_con
              "You can specify a whole path, for example folder1/folder2/folder3. "
              "Any folders that do not exist are automatically created.")
 @option("-p", "--preset", help="The upload preset to use.")
-@option("-c", "--directory-contents-only", is_flag=True, help="Avoid creating the directory as a subfolder of the "
-                                                              "--(f)older in Cloudinary. This will only upload the "
-                                                              "contents of the directory argument.")
+@option(" /-P", "--use-parent-dir/--dont-use-parent-dir",
+        default=True,
+        help="If \"--use-parent-dir\" is set, default behavior, the parent directory would be created as a subfolder of"
+             "the --(f)older in Cloudinary. "
+             "If \"--dont-use-parent-dir\" is set, only upload the contents of the directory argument.")
 @option("-w", "--concurrent_workers", type=int, default=30, help="Specify the number of concurrent network threads.")
 def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, optional_parameter_parsed, transformation,
-               folder, preset, concurrent_workers, directory_contents_only):
+               folder, preset, concurrent_workers, use_parent_dir):
     items, skipped = {}, {}
 
     dir_to_upload = Path(path_join(getcwd(), directory))
@@ -58,10 +60,10 @@ def upload_dir(directory, glob_pattern, include_hidden, optional_parameter, opti
             if not include_hidden and is_hidden_path(file_path):
                 continue
 
-            if directory_contents_only:
-                destination_folder = get_destination_folder(folder, str(file_path))
-            else:
+            if use_parent_dir:
                 destination_folder = get_destination_folder(folder, str(file_path), parent=parent)
+            else:
+                destination_folder = get_destination_folder(folder, str(file_path))
 
             options = {**options, "folder": destination_folder}
             uploads.append((file_path, options, items, skipped))

--- a/test/test_modules/test_cli_upload_dir.py
+++ b/test/test_modules/test_cli_upload_dir.py
@@ -36,3 +36,20 @@ class TestCLIUploadDir(unittest.TestCase):
 
         self.assertEqual(0, result.exit_code)
         self.assertIn("11 resources uploaded", result.output)
+
+    def test_upload_dir_with_parent_dir_option(self):
+        result = self.runner.invoke(cli, ["upload_dir", TEST_FILES_DIR, "--use-parent-dir", "-f", self.CLD_UPLOAD_DIR])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("12 resources uploaded", result.output)
+        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/NoSpaces/OrdinaryFilename", result.output)
+        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/Speed_Grip 3_05_200x200", result.output)
+
+    def test_upload_dir_without_parent_dir_option(self):
+        result = self.runner.invoke(cli,
+                                    ["upload_dir", TEST_FILES_DIR, "--dont-use-parent-dir", "-f", self.CLD_UPLOAD_DIR])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("12 resources uploaded", result.output)
+        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/NoSpaces/OrdinaryFilename", result.output)
+        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/Speed_Grip 3_05_200x200", result.output)

--- a/test/test_modules/test_cli_upload_dir.py
+++ b/test/test_modules/test_cli_upload_dir.py
@@ -37,17 +37,16 @@ class TestCLIUploadDir(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
         self.assertIn("11 resources uploaded", result.output)
 
-    def test_upload_dir_with_parent_dir_option(self):
-        result = self.runner.invoke(cli, ["upload_dir", TEST_FILES_DIR, "--use-parent-dir", "-f", self.CLD_UPLOAD_DIR])
+    def test_upload_dir_without_exclude_dir_name_option(self):
+        result = self.runner.invoke(cli, ["upload_dir", TEST_FILES_DIR, "-f", self.CLD_UPLOAD_DIR])
 
         self.assertEqual(0, result.exit_code)
         self.assertIn("12 resources uploaded", result.output)
         self.assertIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/NoSpaces/OrdinaryFilename", result.output)
         self.assertIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/Speed_Grip 3_05_200x200", result.output)
 
-    def test_upload_dir_without_parent_dir_option(self):
-        result = self.runner.invoke(cli,
-                                    ["upload_dir", TEST_FILES_DIR, "--dont-use-parent-dir", "-f", self.CLD_UPLOAD_DIR])
+    def test_upload_dir_with_exclude_dir_name_option(self):
+        result = self.runner.invoke(cli, ["upload_dir", TEST_FILES_DIR, "-e", "-f", self.CLD_UPLOAD_DIR])
 
         self.assertEqual(0, result.exit_code)
         self.assertIn("12 resources uploaded", result.output)

--- a/test/test_modules/test_cli_upload_dir.py
+++ b/test/test_modules/test_cli_upload_dir.py
@@ -42,13 +42,12 @@ class TestCLIUploadDir(unittest.TestCase):
 
         self.assertEqual(0, result.exit_code)
         self.assertIn("12 resources uploaded", result.output)
-        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/NoSpaces/OrdinaryFilename", result.output)
-        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/Speed_Grip 3_05_200x200", result.output)
+        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/", result.output)
 
     def test_upload_dir_with_exclude_dir_name_option(self):
         result = self.runner.invoke(cli, ["upload_dir", TEST_FILES_DIR, "-e", "-f", self.CLD_UPLOAD_DIR])
 
         self.assertEqual(0, result.exit_code)
         self.assertIn("12 resources uploaded", result.output)
-        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/NoSpaces/OrdinaryFilename", result.output)
-        self.assertIn("as " + self.CLD_UPLOAD_DIR + "/Speed_Grip 3_05_200x200", result.output)
+        self.assertIn("as " + self.CLD_UPLOAD_DIR, result.output)
+        self.assertNotIn("as " + self.CLD_UPLOAD_DIR + "/test_sync/", result.output)


### PR DESCRIPTION
### Brief Summary of Changes

Add the ability to upload the contents of a local directory without requiring that the parent directory (the `local_folder`) be created in Cloudinary. 

Without this change, it is impossible to use `cld upload_dir` to upload a local directory's contents to Cloudinary without also creating a directory/folder within Cloudinary that also has the same name.

This was implemented by introducing new `--exclude-dir-name (-e)` command option that allowa the user to decide if the local parent directory should be created in Cloudinary, or just its contents.


**Example without flag**
Upload the local folder, `my_images`, and all its contents and sub-folders to the Cloudinary folder `my_images_on_cloudinary`, overwriting existing files. This example was pulled from the [Cloudinary CLI documentation](https://cloudinary.com/documentation/cloudinary_cli#upload_dir).  

```console
cld upload_dir -f my_images_on_cloudinary -o overwrite true my_images
```

This would result in the following folder structure in Cloudinary:

```
    Home
    +--my_images_on_cloudinary
    |  +-- my_images
    |  |   +-- <all assets and sub-folders of my_images>
```

**Example using new -e (--exclude-dir-name) flag**
Upload the *contents* of local folder, `my_images`, and all sub-folders to the Cloudinary folder `my_images_on_cloudinary`, overwriting existing files. 

```console
cld upload_dir -f my_images_on_cloudinary -e -o overwrite true my_images
```
This would result in the following folder structure in Cloudinary:

```
    Home
    +-- my_images_on_cloudinary
    |  +-- <all assets and sub-folders of my_images>
```


#### What does this PR address?
- [x] GitHub issue (#64)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
