### PR TITLE
feat(sync): #94 add dry run option to simulate sync operations

### DIFF
--- a/cloudinary_cli/modules/sync.py
+++ b/cloudinary_cli/modules/sync.py
@@ -116,16 +116,16 @@ class SyncDir:
         local_file_names = self.local_files.keys()
         remote_file_names = self.remote_files.keys()
         """
-        Cloudinary is a very permissive service. When uploading files that contain invalid characters, 
-        unicode characters, etc, Cloudinary does the best effort to store those files. 
-        
-        Usually Cloudinary sanitizes those file names and strips invalid characters. Although it is a good best effort 
-        for a general use case, when syncing local folder with Cloudinary, it is not the best option, since directories 
+        Cloudinary is a very permissive service. When uploading files that contain invalid characters,
+        unicode characters, etc, Cloudinary does the best effort to store those files.
+
+        Usually Cloudinary sanitizes those file names and strips invalid characters. Although it is a good best effort
+        for a general use case, when syncing local folder with Cloudinary, it is not the best option, since directories
         will be always out-of-sync.
-        
+
         In addition in dynamic folder mode Cloudinary allows having identical display names for differrent files.
-         
-        To overcome this limitation, cloudinary-cli keeps .cld-sync hidden file in the sync directory that contains a 
+
+        To overcome this limitation, cloudinary-cli keeps .cld-sync hidden file in the sync directory that contains a
         mapping of the diverse file names. This file keeps tracking of the files and allows syncing in both directions.
         """
 
@@ -172,7 +172,7 @@ class SyncDir:
         if self.dry_run:
             logger.info("Dry run mode enabled. The following files would be uploaded:")
             for file in files_to_push:
-                logger.info(f"{file} -> {self.remote_files[file]['normalized_path']}")
+                logger.info(f"{file}")
             return True
 
 
@@ -222,13 +222,13 @@ class SyncDir:
 
         if not files_to_pull:
             return True
-        
+
         logger.info(f"Preparing to download {len(files_to_pull)} items from Cloudinary folder ")
 
         if self.dry_run:
             logger.info("Dry run mode enabled. The following files would be downloaded:")
             for file in files_to_pull:
-                logger.info(f"{self.remote_files[file]['normalized_path']} -> {file}")
+                logger.info(f"{file}")
             return True
 
         logger.info(f"Downloading {len(files_to_pull)} files from Cloudinary")

--- a/cloudinary_cli/modules/sync.py
+++ b/cloudinary_cli/modules/sync.py
@@ -175,7 +175,6 @@ class SyncDir:
                 logger.info(f"{file}")
             return True
 
-
         logger.info(f"Uploading {len(files_to_push)} items to Cloudinary folder '{self.user_friendly_remote_dir}'")
 
         options = {
@@ -364,6 +363,10 @@ class SyncDir:
 
             # Each batch is further chunked by a deletion batch size that can be specified by the user.
             for deletion_batch in chunker(batch, self.deletion_batch_size):
+                if self.dry_run:
+                    logger.info(f"Dry run mode enabled. Would delete {len(deletion_batch)} resources:\n" +
+                                                "\n".join(deletion_batch))
+                    continue
                 res = api.delete_resources(deletion_batch, invalidate=True, resource_type=attrs[0], type=attrs[1])
                 num_deleted = Counter(res['deleted'].values())["deleted"]
                 if self.verbose:
@@ -411,6 +414,9 @@ class SyncDir:
         logger.info(f"Deleting {len(self.unique_local_file_names)} local files...")
         for file in self.unique_local_file_names:
             full_path = path.abspath(self.local_files[file]['path'])
+            if self.dry_run:
+                logger.info(f"Dry run mode enabled. Would delete '{full_path}'")
+                continue
             remove(full_path)
             logger.info(f"Deleted '{full_path}'")
 

--- a/test/test_modules/test_cli_sync.py
+++ b/test/test_modules/test_cli_sync.py
@@ -184,3 +184,36 @@ class TestCLISync(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
         self.assertIn("Skipping 12 items", result.output)
         self.assertIn("Done!", result.output)
+
+
+    @retry_assertion
+    def test_cli_sync_push_dry_run(self):
+        self._upload_sync_files(TEST_FILES_DIR)
+
+        # wait for indexing to be updated
+        time.sleep(self.GRACE_PERIOD)
+
+        result = self.runner.invoke(cli, ['sync', '--push', '-F', self.LOCAL_PARTIAL_SYNC_DIR, self.CLD_SYNC_DIR, '--dry-run'])
+
+        # check that no files were uploaded
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("Dry run mode enabled. The following files would be uploaded:", result.output)
+        self.assertIn("Done!", result.output)
+
+
+    @retry_assertion
+    def test_cli_sync_pull_dry_run(self):
+        self._upload_sync_files(TEST_FILES_DIR)
+
+        # wait for indexing to be updated
+        time.sleep(self.GRACE_PERIOD)
+
+        shutil.copytree(self.LOCAL_PARTIAL_SYNC_DIR, self.LOCAL_SYNC_PULL_DIR)
+
+        result = self.runner.invoke(cli, ['sync', '--pull', '-F', self.LOCAL_SYNC_PULL_DIR, self.CLD_SYNC_DIR, '--dry-run'])
+
+        # check that no files were downloaded
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("Dry run mode enabled. The following files would be downloaded:", result.output)
+        self.assertIn("Done!", result.output)
+        


### PR DESCRIPTION
### Brief Summary of Changes

- added a `--dry-run` option to the sync command

- included test cases for `push` and `pull` with `--dry-run` enabled

- allows users to preview which files would be uploaded or downloaded without making any changes.

- this feature helps users verify their sync operations before execution


#### What does this PR address?
- [x] GitHub issue (#94)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests
- closes #94 

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
