### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,6 @@
-FROM python:3.9-slim
-RUN pip3 install cloudinary-cli --no-cache
+ARG PYTHON_VERSION
+FROM python:${PYTHON_VERSION:-3.12-slim}
+
+RUN pip3 install --no-cache cloudinary-cli
+
+ENTRYPOINT [ "cloudinary" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
+# syntax=docker/dockerfile:1
+
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION:-3.12-slim}
+
+# For available labels, see OCI Annotations Spec docs:
+# https://specs.opencontainers.org/image-spec/annotations/#pre-defined-annotation-keys
+LABEL org.opencontainers.image.source="https://github.com/cloudinary/cloudinary-cli"
 
 RUN pip3 install --no-cache cloudinary-cli
 


### PR DESCRIPTION
- Add `ENTRYPOINT`, so now it's just `docker run -it cloudinary [command]`.
- Bump Python version to (almost) latest 3.12. Note: 3.13.0 was released just last week (as of 15-Oct).
- Add a `PYHTON_VERSION` [build ARG](https://docs.docker.com/build/building/variables/#build-arguments) to use a specific Python base image version to build from.

-------

### Brief Summary of Changes

#### What does this PR address?
- [x] GitHub issue (#25, follow-up to #96)
- [ ] Refactoring
- [x] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
Follow-up of #96.
Notice that current `Dockerfile` is not a _source build_, but a download-from-pypi-and-install build, and it is not pinned to any version. It'll suffice for a "Just Build :tm:" from repo one liner to hit the road ASAP:
```console
$ # Build image straight from source Github repo URL (no clone needed)
$ docker build -t cloudinary https://github.com/cloudinary/cloudinary-cli.git#main
$ # Profit!
$ docker run --rm -it cloudinary config
```
But it won't work for local development workflow.

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.